### PR TITLE
Mathml fix

### DIFF
--- a/MathJax-on-Wikipedia.user.js
+++ b/MathJax-on-Wikipedia.user.js
@@ -1,36 +1,36 @@
 // ==UserScript==
 // @name        MathJax on Wikipedias
 // @namespace   https://github.com/came88
-// @version     0.1.8
+// @version     0.2.0
 // @description Replace PNG math images with MathJax HTML+CSS rendering on all wikipedias
 // @author      Lorenzo Cameroni
 // @license     GPLv2; https://www.gnu.org/licenses/gpl-2.0.html
 // @homepage    https://github.com/came88/MathJax-on-Wikipedia
 // @downloadURL https://github.com/came88/MathJax-on-Wikipedia/raw/master/MathJax-on-Wikipedia.user.js
 // @match       https://*.wikipedia.org/wiki/*
-// @require     https://code.jquery.com/jquery-2.2.4.min.js
+// @require     https://code.jquery.com/jquery-1.12.4.min.js
 // @grant       unsafeWindow
 // ==/UserScript==
 
 /*
  *
  * MathJax on Wikipedias
- * 
+ *
  * This user script replace math PNG images in wikipedia with MathJax rendering of original formulas,
  * while keeping original PNG as preview until MathJax has finished rendering.
- * 
- * Copyright (C) 2015  Lorenzo Cameroni
- * 
+ *
+ * Copyright (C) 2015-2016  Lorenzo Cameroni
+ *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * as published by the Free Software Foundation; either version 2
  * of the License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
@@ -76,121 +76,90 @@ var commonConfig = {
 		extensions: ["autoload-all.js", "mediawiki-texvc.js"]
 	}
 };
- 
+
+function loadMathjax (url, config) {
+	var configScript = document.createElement("script");
+	configScript.type = "text/x-mathjax-config";
+	$(configScript).text(config);
+	$("head").append(configScript);
+	var loadScript = document.createElement("script");
+	loadScript.type = "text/javascript";
+	loadScript.src = url;
+	$("head").append(loadScript);
+}
+
 function wikipediaPNG(images) {
 	console.log("Replacing PNG images with MathJax...");
-	var script;
-	for (var i = 0; i < images.length; i++) {
-		var img = images.get(i);
-		var tex = img.alt;
-		var span = document.createElement("span");
-		span.className = "MathJax_hide_me";
-		$(img).before(span);
-		$(img).detach().appendTo(span);
-		script = document.createElement("script");
-		if (img.className.indexOf("mwe-math-fallback-image-display") > -1) {
+	images.each(function() {
+		var tex = this.alt;
+		var script = document.createElement("script");
+		if ($(this).hasClass("mwe-math-fallback-image-display")) {
 			script.type = "math/tex; mode=display";
 		} else {
 			script.type = "math/tex";
 		}
-		script[(window.opera ? "innerHTML" : "text")] = "\\displaystyle " + tex;
-		$(span).after(script);
-	}
-
-	// Load MathJax
-	script = document.createElement("script");
-	script.type = "text/x-mathjax-config";
+		$(script).text("\\displaystyle " + tex);
+		$(this).after(script);
+		var span = document.createElement("span");
+		span.className = "MathJax_hide_me";
+		$(this).wrap(span);
+	});
 	var config = commonConfig;
 	// Disable fast Common-HTML preview (we already have PNG previews...)
 	config.preview = "none";
 	config["CHTML-preview"] = {
 		disabled: true
 	};
-	script[(window.opera ? "innerHTML" : "text")] = "MathJax.Hub.Config(" + JSON.stringify(config) + ");";
-    // console.log(script[(window.opera ? "innerHTML" : "text")]);
-	$("head").append(script);
-	script = document.createElement("script");
-	script.type = "text/javascript";
-	script.src = "https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS_HTML,Safe";
-	$("head").append(script);
+	loadMathjax("https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS_HTML,Safe",
+		"MathJax.Hub.Config(" + JSON.stringify(config) + ");");
 }
 
 function wikipediaTextual(spans) {
 	console.log("Replacing LaTeX with MathJax...");
 
-	var script;
-	for (var i = 0; i < spans.length; i++) {
-		var span = spans.get(i);
-		var tex = span.innerHTML;
+	spans.each(function(){
+		var tex = $(this).text();
 		tex = tex.substring(1, tex.length - 2);
 		script = document.createElement("script");
-		if (span.className.indexOf("mwe-math-fallback-source-display") > -1) {
+		if ($(this).hasClass("mwe-math-fallback-source-display")) {
 			script.type = "math/tex; mode=display";
 		} else {
 			script.type = "math/tex";
 		}
-		span.className = "MathJax_hide_me";
-		script[(window.opera ? "innerHTML" : "text")] = "\\displaystyle " + tex;
-		$(span).after(script);
-	}
-
-	// Load MathJax
-	script = document.createElement("script");
-	script.type = "text/x-mathjax-config";
-	var config = commonConfig;
-	script[(window.opera ? "innerHTML" : "text")] = "MathJax.Hub.Config(" + JSON.stringify(config) + ");";
-    console.log(script[(window.opera ? "innerHTML" : "text")]);
-	$("head").append(script);
-	script = document.createElement("script");
-	script.type = "text/javascript";
-	script.src = "https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS_HTML,Safe";
-	$("head").append(script);
+		this.className = "MathJax_hide_me";
+		$(script).text("\\displaystyle " + tex);
+		$(this).after(script);
+	});
+	loadMathjax("https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS_HTML,Safe",
+		"MathJax.Hub.Config(" + JSON.stringify(commonConfig) + ");");
 }
 
-function wikipediaMathML() {
-	console.log("Replacing MathML with MathJax...");
-	
-	// Load MathJax
-	script = document.createElement("script");
-	script.type = "text/x-mathjax-config";
+function wikipediaMathML(mathML) {
+	console.log("Replacing MathML/SVG/PNG with MathJax...");
+	// get LaTeX source annotated inside MathML
+	mathML.each(function(){
+		var img = $(this).parent().parent().find("img");
+		var span = document.createElement("span");
+		span.className = "MathJax_hide_me";
+		$(img).wrap(span);
+		var tex = $(this).find("annotation").text();
+		script = document.createElement("script");
+		if ($(this).parent().hasClass("mwe-math-fallback-source-display")) {
+			script.type = "math/tex; mode=display";
+		} else {
+			script.type = "math/tex";
+		}
+		$(script).text("\\displaystyle " + tex);
+		$(this).parent().append(script);
+	});
 	var config = commonConfig;
-	// Disable fast Common-HTML preview (we already have PNG previews...)
+	// Disable fast Common-HTML preview (now there are SVG/PNG previews...)
 	config.preview = "none";
 	config["CHTML-preview"] = {
 		disabled: true
 	};
-	script[(window.opera ? "innerHTML" : "text")] = "MathJax.Hub.Config(" + JSON.stringify(config) + ");";
-    // console.log(script[(window.opera ? "innerHTML" : "text")]);
-	$("head").append(script);
-	
-	// swap span, so preview is BEFORE MathML
-	var maths = $(".mwe-math-mathml-a11y");
-	for (i = 0; i < maths.length; i++) {
-		spanMath = $(maths[i]);
-		img = spanMath.parent().find("img");
-		var span = document.createElement("span");
-		span.className = "MathJax_hide_me";
-		$(img).before(span);
-		$(img).detach().appendTo(span);
-		tex = spanMath.find("annotation").text();
-		
-		script = document.createElement("script");
-		if (maths[i].className.indexOf("mwe-math-fallback-source-display") > -1) {
-			script.type = "math/tex; mode=display";
-		} else {
-			script.type = "math/tex";
-		}
-		script[(window.opera ? "innerHTML" : "text")] = "\\displaystyle " + tex;
-		spanMath.parent().append(script);
-	}
-	
-//	$(".mwe-math-fallback-image-inline, .mwe-math-fallback-image-display").addClass("MathJax_hide_me");
-//	$(".mwe-math-mathml-a11y").removeClass("mwe-math-mathml-a11y");
-	
-	script = document.createElement("script");
-	script.type = "text/javascript";
-	script.src = "https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS_HTML,Safe";
-	$("head").append(script);
+	loadMathjax("https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS_HTML,Safe",
+		"MathJax.Hub.Config(" + JSON.stringify(config) + ");");
 }
 
 // Load MathJax only if no one else (the webpage, another browser extension...) has already loaded it
@@ -202,7 +171,7 @@ if (window.MathJax === undefined && (window.unsafeWindow === undefined || window
 	} else {
 		var mathML = $("math");
 		if (mathML.length > 0) {
-			wikipediaMathML();
+			wikipediaMathML(mathML);
 		} else {
 			var spans = $("span.tex");
 			if (spans.length > 0) {

--- a/MathJax-on-Wikipedia.user.js
+++ b/MathJax-on-Wikipedia.user.js
@@ -8,7 +8,7 @@
 // @homepage    https://github.com/came88/MathJax-on-Wikipedia
 // @downloadURL https://github.com/came88/MathJax-on-Wikipedia/raw/master/MathJax-on-Wikipedia.user.js
 // @match       https://*.wikipedia.org/wiki/*
-// @require     https://code.jquery.com/jquery-1.11.3.min.js
+// @require     https://code.jquery.com/jquery-2.2.4.min.js
 // @grant       unsafeWindow
 // ==/UserScript==
 
@@ -153,27 +153,43 @@ function wikipediaMathML() {
 	// Load MathJax
 	script = document.createElement("script");
 	script.type = "text/x-mathjax-config";
-	var config = {
-		extensions: ["Safe.js"],
-		preview: "none",
-		"CHTML-preview": {
-			disabled: true
-		}/*,
-		"HTML-CSS": {
-			EqnChunk: 1,
-			EqnChunkFactor: 1,
-			EqnChunkDelay: 10
-		}*/
+	var config = commonConfig;
+	// Disable fast Common-HTML preview (we already have PNG previews...)
+	config.preview = "none";
+	config["CHTML-preview"] = {
+		disabled: true
 	};
 	script[(window.opera ? "innerHTML" : "text")] = "MathJax.Hub.Config(" + JSON.stringify(config) + ");";
     // console.log(script[(window.opera ? "innerHTML" : "text")]);
 	$("head").append(script);
-	$("meta.mwe-math-fallback-image-inline").remove();
-	$("meta.mwe-math-fallback-image-display").remove();
-	$(".mwe-math-mathml-a11y").removeClass("mwe-math-mathml-a11y");
+	
+	// swap span, so preview is BEFORE MathML
+	var maths = $(".mwe-math-mathml-a11y");
+	for (i = 0; i < maths.length; i++) {
+		spanMath = $(maths[i]);
+		img = spanMath.parent().find("img");
+		var span = document.createElement("span");
+		span.className = "MathJax_hide_me";
+		$(img).before(span);
+		$(img).detach().appendTo(span);
+		tex = spanMath.find("annotation").text();
+		
+		script = document.createElement("script");
+		if (maths[i].className.indexOf("mwe-math-fallback-source-display") > -1) {
+			script.type = "math/tex; mode=display";
+		} else {
+			script.type = "math/tex";
+		}
+		script[(window.opera ? "innerHTML" : "text")] = "\\displaystyle " + tex;
+		spanMath.parent().append(script);
+	}
+	
+//	$(".mwe-math-fallback-image-inline, .mwe-math-fallback-image-display").addClass("MathJax_hide_me");
+//	$(".mwe-math-mathml-a11y").removeClass("mwe-math-mathml-a11y");
+	
 	script = document.createElement("script");
 	script.type = "text/javascript";
-	script.src = "https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=MML_HTMLorMML,Safe";
+	script.src = "https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS_HTML,Safe";
 	$("head").append(script);
 }
 


### PR DESCRIPTION
Wikipedia has changed the default math rendering mode in MathML + SVG fallback + PNG fallback.
This should make the script work again.
The code has been refactored in order to make id more readable
Version bumped to 0.2.0
jQuery bumped to 1.12.4
